### PR TITLE
(paper) Support more Minecraft versions

### DIFF
--- a/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
+++ b/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
@@ -3,8 +3,6 @@ package me.dreamerzero.miniplaceholders.paper;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.dedicated.DedicatedServer;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -20,6 +18,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.MinecraftServer;
 
 public final class PaperPlugin extends JavaPlugin implements PlaceholdersPlugin, Listener {
     private final NumberFormat tpsFormat = NumberFormat.getInstance();

--- a/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
+++ b/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
@@ -1,11 +1,10 @@
 package me.dreamerzero.miniplaceholders.paper;
 
-import java.lang.reflect.InvocationTargetException;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
-import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -84,7 +83,7 @@ public final class PaperPlugin extends JavaPlugin implements PlaceholdersPlugin,
     @Override
     @SuppressWarnings("all")
     public void registerPlatformCommand() {
-        this.getNMSServer()
+        MinecraftServer.getServer()
             .vanillaCommandDispatcher
             .getDispatcher()
             .register(new PlaceholdersCommand<>(
@@ -93,14 +92,5 @@ public final class PaperPlugin extends JavaPlugin implements PlaceholdersPlugin,
                     CommandSourceStack::getBukkitSender
                 ).placeholderTestBuilder("miniplaceholders")
             );
-    }
-
-    private DedicatedServer getNMSServer(){
-        Server craftServer = this.getServer();
-        try {
-            return (DedicatedServer) craftServer.getClass().getDeclaredMethod("getServer").invoke(craftServer);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
-            throw new RuntimeException("Your Minecraft version is not supported by MiniPlaceholders", exception);
-        }
     }
 }

--- a/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
+++ b/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
@@ -1,10 +1,12 @@
 package me.dreamerzero.miniplaceholders.paper;
 
+import java.lang.reflect.InvocationTargetException;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 
+import net.minecraft.server.dedicated.DedicatedServer;
+import org.bukkit.Server;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -48,9 +50,9 @@ public final class PaperPlugin extends JavaPlugin implements PlaceholdersPlugin,
             .globalPlaceholder("version", TagsUtils.staticTag(this.getServer().getVersion()))
             .globalPlaceholder("max_players", (queue, ctx) -> TagsUtils.staticTag(Component.text(this.getServer().getMaxPlayers())))
             .globalPlaceholder("unique_joins", (queue, ctx) -> TagsUtils.staticTag(Component.text(this.getServer().getOfflinePlayers().length)))
-            .globalPlaceholder("tps_1", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getCraftServer().getHandle().getServer().recentTps[0])))
-            .globalPlaceholder("tps_5", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getCraftServer().getHandle().getServer().recentTps[1])))
-            .globalPlaceholder("tps_15", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getCraftServer().getHandle().getServer().recentTps[2])))
+            .globalPlaceholder("tps_1", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getNMSServer().recentTps[0])))
+            .globalPlaceholder("tps_5", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getNMSServer().recentTps[1])))
+            .globalPlaceholder("tps_15", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getNMSServer().recentTps[2])))
             .globalPlaceholder("has_whitelist", (queue, ctx) -> TagsUtils.staticTag(Component.text(this.getServer().hasWhitelist())))
             .globalPlaceholder("total_chunks", (queue, ctx) -> {
                 int chunkCount = 0;
@@ -82,7 +84,7 @@ public final class PaperPlugin extends JavaPlugin implements PlaceholdersPlugin,
     @Override
     @SuppressWarnings("all")
     public void registerPlatformCommand() {
-        this.getCraftServer().getServer()
+        this.getNMSServer()
             .vanillaCommandDispatcher
             .getDispatcher()
             .register(new PlaceholdersCommand<>(
@@ -93,7 +95,12 @@ public final class PaperPlugin extends JavaPlugin implements PlaceholdersPlugin,
             );
     }
 
-    private CraftServer getCraftServer(){
-        return (CraftServer)this.getServer();
+    private DedicatedServer getNMSServer(){
+        Server craftServer = this.getServer();
+        try {
+            return (DedicatedServer) craftServer.getClass().getDeclaredMethod("getServer").invoke(craftServer);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
+            throw new RuntimeException("Your Minecraft version is not supported by MiniPlaceholders", exception);
+        }
     }
 }

--- a/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
+++ b/paper/src/main/java/me/dreamerzero/miniplaceholders/paper/PaperPlugin.java
@@ -50,9 +50,9 @@ public final class PaperPlugin extends JavaPlugin implements PlaceholdersPlugin,
             .globalPlaceholder("version", TagsUtils.staticTag(this.getServer().getVersion()))
             .globalPlaceholder("max_players", (queue, ctx) -> TagsUtils.staticTag(Component.text(this.getServer().getMaxPlayers())))
             .globalPlaceholder("unique_joins", (queue, ctx) -> TagsUtils.staticTag(Component.text(this.getServer().getOfflinePlayers().length)))
-            .globalPlaceholder("tps_1", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getNMSServer().recentTps[0])))
-            .globalPlaceholder("tps_5", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getNMSServer().recentTps[1])))
-            .globalPlaceholder("tps_15", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getNMSServer().recentTps[2])))
+            .globalPlaceholder("tps_1", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getServer().getTPS()[0])))
+            .globalPlaceholder("tps_5", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getServer().getTPS()[1])))
+            .globalPlaceholder("tps_15", (queue, ctx) -> TagsUtils.staticTag(tpsFormat.format(this.getServer().getTPS()[2])))
             .globalPlaceholder("has_whitelist", (queue, ctx) -> TagsUtils.staticTag(Component.text(this.getServer().hasWhitelist())))
             .globalPlaceholder("total_chunks", (queue, ctx) -> {
                 int chunkCount = 0;


### PR DESCRIPTION
This PR adds support for 1.19.1 and (very likely) future Minecraft versions, and replaces NMS-dependent `recentTps` field with Paper's `getTPS()`.